### PR TITLE
Add support and instructions for running the dashboard via docker

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,4 @@
+FROM rocker/shiny-verse:4.4.1
+
+RUN Rscript -e \
+    'install.packages(c("shiny", "shinyWidgets", "shinythemes", "shinycssloaders", "DT", "RcppTOML", "tidyverse", "gridExtra", "paletteer"), repos="https://cloud.r-project.org")'

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -5,3 +5,41 @@ This folder contains code for the visual analytics to support rapid plan compari
 For efficient load-times, the results from scripts in the `postScripts/` are loaded, formatted, and compressed in the `dataRetrieval.py` file and stored in a `data/` directory in the same folder.
 
 To run the dashboard, you can launch from R Studio or from the terminal using `shiny::runApp()`.
+
+## Running with Docker
+
+In some cases it may be easiest to setup a suitable R environment using Docker.
+The following instructions assume you have docker installed and a local cloned copy of the repository.
+
+At a high level, the provided `Dockerfile` contains the instructions for installing the necessary R dependencies required to run the dashboard.
+The provided `docker-compose.yml` file contains configuration information used by the `docker` command line utility for both building the docker image running the dashboard.
+When the dashboard is run using docker, your local cloned copy of this repository will be mounted into the docker container at `/data`.
+Likewise, the shiny app is mounted into the container at `/app/app.R`.
+The dashboard is exposed on the local host loopback device on port 8080 (connect at http://localhost:8080).
+
+Instructions are provided in the `docker-compose.yml` file if there is a need to run the dashboard container for develop / debugging purposes.
+
+### Building Docker image
+
+```shell
+# run from this directory
+docker compose build
+```
+
+> [!NOTE]
+> If you are running on arm architecture (e.g. M-series mac) you may need to build the image using the following command instead:
+> `DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose build`
+
+### Running Dashboard
+
+```shell
+# run from this directory
+docker compose up
+
+# use ctrl+c to stop the container
+
+# remove the container using
+docker compose down
+```
+
+Connect to the dashboard at http://localhost:8080.

--- a/dashboard/app.R
+++ b/dashboard/app.R
@@ -5,7 +5,10 @@
 print("... setting up script ...")
 
 # set working directory
-setwd("/Users/kylasemmendinger/Documents/github/loslr_regulation_optimization")
+default_working_directory="/Users/kylasemmendinger/Documents/github/loslr_regulation_optimization"
+working_directory = Sys.getenv("working_directory", default_working_directory)[1]
+print(paste0("using working directory: ", working_directory))
+setwd(working_directory)
 # setwd("/Users/kylasemmendinger/Library/CloudStorage/GoogleDrive-kylasr@umich.edu/My Drive/loslrRegulation")
 
 # # clean up

--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  # To develop / debug the dashboard using docker, see the NOTE: sections below.
+  # NOTE: To start a terminal session connected to the dashboard container use:
+  # docker compose run --rm --service-ports dashboard
+  # If you are on an arm platform (e.g. mac M-series) you may need to run instead:
+  # DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose run --rm --service-ports dashboard
+  dashboard:
+    image: dashboard
+    container_name: dashboard
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    # NOTE: uncomment 'entrypoint: bash' and comment out the following
+    # 'entrypoint' for development / debugging.
+    # Use command in the uncommented entrypoint to start the rshiny server from bash.
+    # entrypoint: bash
+    entrypoint: Rscript -e 'library(shiny); runApp("app", host="0.0.0.0", port=8080)'
+    environment:
+      - working_directory=/data
+    volumes:
+      # NOTE: The ':ro' suffix mounts the directories in read-only mode.
+      # Remove the ':ro' suffix to modify local files in or out of the container for debugging or development purposes.
+      - "../:/data:ro"
+      - "./app.R:/app/app.R"
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
In some cases it may be easiest to setup a suitable R environment using Docker. This PR add the necessary assets to build and run the dashboard using docker.